### PR TITLE
add note about code coverage to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ A Teaspoon boot partial and controller that serves up all the test assets into a
 
 1. Add `teaspoon-bundle` to your `Gemfile` and run `bundle install`.
 2. Add `suite.boot_partial = "bundle_boot"` to your `teaspoon_env.rb`.
+
+## Known Issues
+
+`teaspoon-bundle` is known to break code coverage provided by teaspoon.


### PR DESCRIPTION
Its known that code coverage through teaspoon doesn't work with `teaspoon-bundle`. Exact cause is unknown at this point. This PR adds a note to the Readme to let people know we are aware and hopefully save them some time from checking basic config for errors.

@bouk 
