### PR TITLE
Add skip_forgery_protection to BundleController

### DIFF
--- a/app/controllers/teaspoon/bundle/bundle_controller.rb
+++ b/app/controllers/teaspoon/bundle/bundle_controller.rb
@@ -1,5 +1,7 @@
 module Teaspoon::Bundle
   class BundleController < ActionController::Base
+    skip_forgery_protection if default_protect_from_forgery
+
     def serve
       file = File.join(Teaspoon::Bundle.dir, "teaspoon_bundle_#{params[:suite]}.js.erb")
       File.write(file, contents)


### PR DESCRIPTION
For applications that adds forgery protection by default we need to skip on the bundle controller so we are able to serve js bundles during teaspoon tests.

Currently I'm experiencing an exception while trying to access the assets that teaspoon serves. The test servers are running great the because it's returning 504 from the bundle endpoint it's possible the tests being skipped.