### PR TITLE
Don't require controller

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Shopify Inc.
+Copyright (c) 2016-present Shopify Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/teaspoon/bundle/engine.rb
+++ b/lib/teaspoon/bundle/engine.rb
@@ -15,7 +15,6 @@ module Teaspoon
 
       config.after_initialize do |app|
         app.routes.prepend do
-          require Teaspoon::Bundle::Engine.root.join("app/controllers/teaspoon/bundle/bundle_controller")
           mount Teaspoon::Bundle::Engine => Teaspoon::Bundle::ENDPOINT, as: 'teaspoon_bundle'
         end
       end

--- a/teaspoon-bundle.gemspec
+++ b/teaspoon-bundle.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "teaspoon"
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13"
+  spec.add_development_dependency "minitest", "~> 5"
 end


### PR DESCRIPTION
The require isn't needed here because `app/controllers` is autoloaded. Requiring this line loads Action Controller early, which slows down boot time on applications.